### PR TITLE
Return frames as a raw []byte

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Cacophony Project. All rights reserved.
+// Copyright 2018 The Cacophony Project. All rights reserved.
 // Use of this source code is governed by the Apache License Version 2.0;
 // see the LICENSE file for further details.
 
@@ -6,80 +6,23 @@ package lepton3
 
 import (
 	"encoding/binary"
-	"fmt"
 )
 
-func newFrame() *frame {
-	f := &frame{
-		segmentPackets: make([][]byte, packetsPerSegment),
-		framePackets:   make([][]byte, packetsPerFrame),
-	}
-	f.reset()
-	return f
-}
+// RawFrame hold the raw bytes for single frame. This is helpful for
+// transferring frames around. It can be converted to the more useful
+// Frame.
+type RawFrame [2 * FrameRows * FrameCols]byte
 
-type frame struct {
-	packetNum      int
-	segmentNum     int
-	segmentPackets [][]byte
-	framePackets   [][]byte
-}
+// Frame represents the thermal readings for a single frame.
+type Frame [FrameRows][FrameCols]uint16
 
-func (f *frame) reset() {
-	f.packetNum = -1
-	f.segmentNum = 0
-}
-
-func (f *frame) nextPacket(packetNum int, packet []byte) (bool, error) {
-	if !f.sequential(packetNum) {
-		return false, fmt.Errorf("out of order packet: %d -> %d", f.packetNum, packetNum)
-	}
-
-	// Store the packet data in current segment
-	f.segmentPackets[packetNum] = packet[vospiHeaderSize:]
-
-	switch packetNum {
-	case segmentPacketNum:
-		segmentNum := int(packet[0] >> 4)
-		if segmentNum > 4 {
-			return false, fmt.Errorf("invalid segment number: %d", segmentNum)
-		}
-		if segmentNum > 0 && segmentNum != f.segmentNum+1 {
-			// XXX this might not warrant a resync but certainly ignoring of the segment
-			return false, fmt.Errorf("out of order segment")
-		}
-		f.segmentNum = segmentNum
-	case maxPacketNum:
-		if f.segmentNum > 0 {
-			// This should be fast as only slice headers for the
-			// segment are being copied, not the packet data itself.
-			copy(f.framePackets[(f.segmentNum-1)*packetsPerSegment:], f.segmentPackets)
-		}
-		if f.segmentNum == 4 {
-			// Complete frame!
-			return true, nil
-		}
-	}
-	f.packetNum = packetNum
-	return false, nil
-}
-
-func (f *frame) sequential(packetNum int) bool {
-	if packetNum == 0 && f.packetNum == maxPacketNum {
-		return true
-	}
-	return packetNum == f.packetNum+1
-}
-
-func (f *frame) output(outFrame *Frame) {
-	for packetNum, packet := range f.framePackets {
-		for i := 0; i < vospiDataSize; i += 2 {
-			x := i >> 1 // divide 2
-			if packetNum%2 == 1 {
-				x += colsPerPacket
-			}
-			y := packetNum >> 1 // divide 2
-			outFrame[y][x] = binary.BigEndian.Uint16(packet[i : i+2])
+// ToFrame converts a RawFrame to a Frame.
+func (rf *RawFrame) ToFrame(out *Frame) {
+	i := 0
+	for y := 0; y < FrameRows; y++ {
+		for x := 0; x < FrameCols; x++ {
+			out[y][x] = binary.BigEndian.Uint16(rf[i : i+2])
+			i += 2
 		}
 	}
 }

--- a/framebuilder.go
+++ b/framebuilder.go
@@ -1,0 +1,77 @@
+// Copyright 2017 The Cacophony Project. All rights reserved.
+// Use of this source code is governed by the Apache License Version 2.0;
+// see the LICENSE file for further details.
+
+package lepton3
+
+import (
+	"fmt"
+)
+
+func newFrameBuilder() *frameBuilder {
+	f := &frameBuilder{
+		segmentPackets: make([][]byte, packetsPerSegment),
+		framePackets:   make([][]byte, packetsPerFrame),
+	}
+	f.reset()
+	return f
+}
+
+type frameBuilder struct {
+	packetNum      int
+	segmentNum     int
+	segmentPackets [][]byte
+	framePackets   [][]byte
+}
+
+func (f *frameBuilder) reset() {
+	f.packetNum = -1
+	f.segmentNum = 0
+}
+
+func (f *frameBuilder) nextPacket(packetNum int, packet []byte) (bool, error) {
+	if !f.sequential(packetNum) {
+		return false, fmt.Errorf("out of order packet: %d -> %d", f.packetNum, packetNum)
+	}
+
+	// Store the packet data in current segment
+	f.segmentPackets[packetNum] = packet[vospiHeaderSize:]
+
+	switch packetNum {
+	case segmentPacketNum:
+		segmentNum := int(packet[0] >> 4)
+		if segmentNum > 4 {
+			return false, fmt.Errorf("invalid segment number: %d", segmentNum)
+		}
+		if segmentNum > 0 && segmentNum != f.segmentNum+1 {
+			// XXX this might not warrant a resync but certainly ignoring of the segment
+			return false, fmt.Errorf("out of order segment")
+		}
+		f.segmentNum = segmentNum
+	case maxPacketNum:
+		if f.segmentNum > 0 {
+			// This should be fast as only slice headers for the
+			// segment are being copied, not the packet data itself.
+			copy(f.framePackets[(f.segmentNum-1)*packetsPerSegment:], f.segmentPackets)
+		}
+		if f.segmentNum == 4 {
+			// Complete frame!
+			return true, nil
+		}
+	}
+	f.packetNum = packetNum
+	return false, nil
+}
+
+func (f *frameBuilder) sequential(packetNum int) bool {
+	if packetNum == 0 && f.packetNum == maxPacketNum {
+		return true
+	}
+	return packetNum == f.packetNum+1
+}
+
+func (f *frameBuilder) output(outFrame *RawFrame) {
+	for packetNum, packet := range f.framePackets {
+		copy(outFrame[packetNum*vospiDataSize:], packet)
+	}
+}

--- a/lepton3.go
+++ b/lepton3.go
@@ -24,9 +24,16 @@ const (
 	vospiDataSize   = 160
 	vospiPacketSize = vospiHeaderSize + vospiDataSize
 
+	//
 	// Packets, segments and frames
-	FrameCols         = 160
-	FrameRows         = 120
+	//
+
+	// FrameCols is the X resolution of the Lepton 3 camera.
+	FrameCols = 160
+
+	// FrameRows is the Y resolution of the Lepton 3 camera.
+	FrameRows = 120
+
 	packetsPerSegment = 60
 	segmentsPerFrame  = 4
 	packetsPerFrame   = segmentsPerFrame * packetsPerSegment
@@ -49,9 +56,6 @@ const (
 	frameTimeout = 10 * time.Second
 )
 
-// Frame represents the thermal readings for a single frame.
-type Frame [FrameRows][FrameCols]uint16
-
 // New returns a new Lepton3 instance.
 func New(spiSpeed int64) *Lepton3 {
 	// The ring buffer is used to avoid memory allocations for SPI
@@ -59,24 +63,24 @@ func New(spiSpeed int64) *Lepton3 {
 	// transfers for at least a single frame.
 	ringChunks := int(math.Ceil(float64(maxPacketsPerFrame) / float64(packetsPerRead)))
 	return &Lepton3{
-		spiSpeed: spiSpeed,
-		ring:     newRing(ringChunks, transferSize),
-		frame:    newFrame(),
-		log:      func(string) {},
+		spiSpeed:     spiSpeed,
+		ring:         newRing(ringChunks, transferSize),
+		frameBuilder: newFrameBuilder(),
+		log:          func(string) {},
 	}
 }
 
 // Lepton3 manages a connection to an FLIR Lepton 3 camera. It is not
 // goroutine safe.
 type Lepton3 struct {
-	spiSpeed int64
-	spiPort  spi.PortCloser
-	spiConn  spi.Conn
-	packetCh chan []byte
-	tomb     *tomb.Tomb
-	ring     *ring
-	frame    *frame
-	log      func(string)
+	spiSpeed     int64
+	spiPort      spi.PortCloser
+	spiConn      spi.Conn
+	packetCh     chan []byte
+	tomb         *tomb.Tomb
+	ring         *ring
+	frameBuilder *frameBuilder
+	log          func(string)
 }
 
 func (d *Lepton3) SetLogFunc(log func(string)) {
@@ -143,19 +147,19 @@ func (d *Lepton3) Close() {
 	d.spiConn = nil
 }
 
-// NextFrame returns the next frame from the camera into the Frame
+// NextFrame returns the next frame from the camera into the RawFrame
 // provided.
 //
-// The output Frame is provided (rather than being created by
+// The output RawFrame is provided (rather than being created by
 // NextFrame) to minimise memory allocations.
 //
 // NextFrame should only be called after a successful call to
 // Open(). Although there is some internal buffering of camera
 // packets, NextFrame must be called frequently enough to ensure
 // frames are not lost.
-func (d *Lepton3) NextFrame(outFrame *Frame) error {
+func (d *Lepton3) NextFrame(outFrame *RawFrame) error {
 	timeout := time.After(frameTimeout)
-	d.frame.reset()
+	d.frameBuilder.reset()
 
 	var packet []byte
 	for {
@@ -180,13 +184,13 @@ func (d *Lepton3) NextFrame(outFrame *Frame) error {
 			continue
 		}
 
-		complete, err := d.frame.nextPacket(packetNum, packet)
+		complete, err := d.frameBuilder.nextPacket(packetNum, packet)
 		if err != nil {
 			if err := d.resync(err); err != nil {
 				return err
 			}
 		} else if complete {
-			d.frame.output(outFrame)
+			d.frameBuilder.output(outFrame)
 			return nil
 		}
 	}
@@ -194,12 +198,12 @@ func (d *Lepton3) NextFrame(outFrame *Frame) error {
 
 // Snapshot is convenience method for capturing a single frame. It
 // should *not* be called if streaming is already active.
-func (d *Lepton3) Snapshot() (*Frame, error) {
+func (d *Lepton3) Snapshot() (*RawFrame, error) {
 	if err := d.Open(); err != nil {
 		return nil, err
 	}
 	defer d.Close()
-	frame := new(Frame)
+	frame := new(RawFrame)
 	if err := d.NextFrame(frame); err != nil {
 		return nil, err
 	}
@@ -209,7 +213,7 @@ func (d *Lepton3) Snapshot() (*Frame, error) {
 func (d *Lepton3) resync(reason error) error {
 	d.log(fmt.Sprintf("resync! %v", reason))
 	d.Close()
-	d.frame.reset()
+	d.frameBuilder.reset()
 	time.Sleep(300 * time.Millisecond)
 	return d.Open()
 }

--- a/leptonutil/main.go
+++ b/leptonutil/main.go
@@ -81,16 +81,19 @@ func runMain() error {
 		log.Printf(t)
 	})
 
+	rawFrame := new(lepton3.RawFrame)
 	frame := new(lepton3.Frame)
 	i := 0
 	for {
-		err := camera.NextFrame(frame)
+		err := camera.NextFrame(rawFrame)
 		if err != nil {
 			return err
 		}
 		fmt.Printf(".")
 
 		if opts.Output == "png" {
+			rawFrame.ToFrame(frame)
+
 			filename := filepath.Join(opts.Directory, fmt.Sprintf("%05d.png", i))
 			err := dumpToPNG(filename, frame)
 			if err != nil {


### PR DESCRIPTION
For transmitting frames between processes (which we're starting to do
now) it's useful to have frames as raw byte slices instead of a 2D
array of ints. The new RawFrame type represents a raw frame and has a
method to allow conversion to the more useful Frame type.

Also renamed the internal `frame` type to `frameBuilder` to avoid
confusion.