### PR TITLE
Simplify raw frame conversion

### DIFF
--- a/framebuilder.go
+++ b/framebuilder.go
@@ -70,6 +70,6 @@ func (f *frameBuilder) sequential(packetNum int) bool {
 	return packetNum == f.packetNum+1
 }
 
-func (f *frameBuilder) output(outFrame *RawFrame) {
-	copy(outFrame[:], f.frameBuf)
+func (f *frameBuilder) output(outFrame []byte) {
+	copy(outFrame, f.frameBuf)
 }

--- a/leptonutil/main.go
+++ b/leptonutil/main.go
@@ -87,7 +87,7 @@ func runMain() error {
 		log.Printf(t)
 	})
 
-	rawFrame := new(lepton3.RawFrame)
+	rawFrame := lepton3.NewRawFrame()
 	frame := cptvframe.NewFrame(camera)
 	i := 0
 	for {
@@ -97,7 +97,9 @@ func runMain() error {
 		}
 		fmt.Printf(".")
 
-		rawFrame.ToFrame(frame)
+		if err := lepton3.ParseRawFrame(rawFrame, frame); err != nil {
+			return err
+		}
 		if opts.Verbose {
 			fmt.Printf("%+v\n", frame.Status)
 		}

--- a/rawframe.go
+++ b/rawframe.go
@@ -6,22 +6,24 @@ import (
 	"github.com/TheCacophonyProject/go-cptv/cptvframe"
 )
 
-type RawFrame [packetsPerFrame * vospiDataSize]byte
-
-func (rf *RawFrame) FrameData() []byte {
-	return rf[telemetryPacketCount*vospiDataSize:]
+// NewRawFrame returns a correctly sized byte slice for holding a
+// single Lepton 3 frame.
+func NewRawFrame() []byte {
+	return make([]byte, BytesPerFrame)
 }
 
-// ToFrame converts a RawFrame to a Frame.
-func (rf *RawFrame) ToFrame(out *cptvframe.Frame) error {
-	if err := ParseTelemetry(rf[:], &out.Status); err != nil {
+// ParseRawFrame converts a byte slice containing a raw Lepton 3 frame
+// into a cptvframe.Frame. The result is writing into the Frame
+// provided.
+func ParseRawFrame(raw []byte, out *cptvframe.Frame) error {
+	if err := ParseTelemetry(raw, &out.Status); err != nil {
 		return err
 	}
 
-	rawPix := rf.FrameData()
+	rawPix := raw[telemetryBytes:]
 	i := 0
 	for y, row := range out.Pix {
-		for x, _ := range row {
+		for x := range row {
 			out.Pix[y][x] = binary.BigEndian.Uint16(rawPix[i : i+2])
 			i += 2
 		}


### PR DESCRIPTION
In order to support other camera types, represent raw frames as byte slices.